### PR TITLE
chore: reuse the tape machine if it has already been created

### DIFF
--- a/backend/x/gorgonnx/graph.go
+++ b/backend/x/gorgonnx/graph.go
@@ -18,6 +18,7 @@ import (
 type Graph struct {
 	g         *simple.WeightedDirectedGraph
 	exprgraph *gorgonia.ExprGraph
+	m         gorgonia.VM
 	roots     []int64
 }
 
@@ -44,8 +45,13 @@ func (g *Graph) Run() error {
 			return err
 		}
 	}
-	t := gorgonia.NewTapeMachine(g.exprgraph)
-	err := t.RunAll()
+	if g.m == nil {
+		g.m = gorgonia.NewTapeMachine(g.exprgraph)
+	} else {
+		g.m.Reset()
+	}
+
+	err := g.m.RunAll()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
```
benchmark           old ns/op     new ns/op     delta
BenchmarkYOLO-4     733923927     734250451     +0.04%

benchmark           old allocs     new allocs     delta
BenchmarkYOLO-4     19045          11570          -39.25%

benchmark           old bytes     new bytes     delta
BenchmarkYOLO-4     184515390     184207324     -0.17%
```