### PR TITLE
Fix the reshape operator when the new shape contains only 1 dimension.

### DIFF
--- a/backend/x/gorgonnx/reshape.go
+++ b/backend/x/gorgonnx/reshape.go
@@ -27,7 +27,11 @@ func (a *reshape) apply(g *Graph, ns ...*Node) error {
 	}
 
 	var toShape tensor.Shape
-	if to, ok := children[1].gorgoniaNode.Value().Data().([]int64); ok {
+	data := children[1].gorgoniaNode.Value().Data()
+	if to, ok := data.(int64); ok {
+		data = []int64{to}
+	}
+	if to, ok := data.([]int64); ok {
 		childShape := make([]int, len(to))
 		copy(childShape, children[0].gorgoniaNode.Shape())
 		toShape = make([]int, len(to))

--- a/backend/x/gorgonnx/reshape_test.go
+++ b/backend/x/gorgonnx/reshape_test.go
@@ -1,0 +1,48 @@
+package gorgonnx
+
+import (
+	"testing"
+
+	"github.com/owulveryck/onnx-go"
+	"github.com/stretchr/testify/assert"
+	"gorgonia.org/tensor"
+)
+
+func TestReshape_Scalar(t *testing.T) {
+
+	inputT := tensor.New(
+		tensor.WithShape(2, 1, 1, 4),
+		tensor.WithBacking([]float32{0, 1, 2, 3, 10000, 10001, 10002, 10003}),
+	)
+	inputShape := tensor.New(
+		tensor.WithShape(1),
+		tensor.WithBacking([]int64{-1}),
+	)
+
+	expectedOutput := tensor.New(
+		tensor.WithShape(8),
+		tensor.WithBacking([]float32{0, 1, 2, 3, 10000, 10001, 10002, 10003}),
+	)
+	g := NewGraph()
+	input1 := g.NewNode()
+	g.AddNode(input1)
+	input2 := g.NewNode()
+	g.AddNode(input2)
+	output := g.NewNode()
+	g.AddNode(output)
+	g.SetWeightedEdge(g.NewWeightedEdge(output, input1, 0))
+	input1.(*Node).SetTensor(inputT)
+	g.SetWeightedEdge(g.NewWeightedEdge(output, input2, 0))
+	input2.(*Node).SetTensor(inputShape)
+	g.ApplyOperation(onnx.Operation{
+		Name: "Reshape",
+	}, output)
+
+	err := g.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	outputT := output.(*Node).GetTensor()
+	assert.InDeltaSlice(t, expectedOutput.Data(), outputT.Data(), 1e-6, "the two tensors should be equal.")
+}


### PR DESCRIPTION
When the new shape only contains one dimension (scalar tensor), tensor.Value().Data() returns an int64 instead of a slice, which leads to the error:
Cannot reshape, bad output shape -1