### PR TITLE
Fix the use of a variable on range scope

### DIFF
--- a/backend/x/gorgonnx/gemm_test.go
+++ b/backend/x/gorgonnx/gemm_test.go
@@ -135,6 +135,7 @@ var testGemm = []struct {
 
 func TestGemm(t *testing.T) {
 	for _, tst := range testGemm {
+		tst := tst
 		t.Run(tst.name, func(t *testing.T) {
 			aT := tst.aT
 			bT := tst.bT


### PR DESCRIPTION
As is, the code isn't wrong, but if concurrency is introduced in the tests, this gonna be a problem.