### PR TITLE
refactor(backend/x/gorgonnx): reduce cyclomatic complexity

### DIFF
--- a/backend/x/gorgonnx/broadcast.go
+++ b/backend/x/gorgonnx/broadcast.go
@@ -15,86 +15,57 @@ func ggnBroadcast(a, b *gorgonia.Node) (*gorgonia.Node, *gorgonia.Node, error) {
 	if sameDim(a, b) {
 		return a, b, nil
 	}
+	return ggnReshapedBroadcast(a, b)
+}
+
+func ggnReshapedBroadcast(a, b *gorgonia.Node) (*gorgonia.Node, *gorgonia.Node, error) {
 	// for NCHW tensors, the first dimension may be omitted and must be broadcasted
 	// TODO find a smarter way to achieve this
+	reshapedA := a
+	reshapedB := b
+	var err error
 	switch {
 	case len(a.Shape()) == 0:
-		bDim := b.Shape()
-		aRDim := make([]int, len(bDim))
-		for i := 0; i < len(bDim); i++ {
-			aRDim[i] = 1
-		}
-		aR, err := gorgonia.Reshape(a, aRDim)
-		if err != nil {
-			return nil, nil, err
-		}
-		return gorgonia.Broadcast(aR, a, getBroadcastPattern(aR, b))
+		reshapedA, err = reshapeNode(a, b, false)
 	case len(b.Shape()) == 0:
-		aDim := a.Shape()
-		bRDim := make([]int, len(aDim))
-		for i := 0; i < len(aDim); i++ {
-			bRDim[i] = 1
-		}
-		bR, err := gorgonia.Reshape(b, bRDim)
-		if err != nil {
-			return nil, nil, err
-		}
-		return gorgonia.Broadcast(a, bR, getBroadcastPattern(a, bR))
+		reshapedB, err = reshapeNode(b, a, false)
 	case len(a.Shape()) == 1 && len(b.Shape()) != 1:
-		// Make an educated guess: find the axis that has the same dimension
-		bShape := b.Shape()
-		dims := make([]int, len(bShape))
-		for i := 0; i < len(bShape); i++ {
-			dims[i] = 1
-			if bShape[i] == a.Shape()[0] {
-				dims[i] = bShape[i]
-			}
-		}
-		// Reshape node a
-		aR, err := gorgonia.Reshape(a, dims)
-		if err != nil {
-			return nil, nil, err
-		}
-		return gorgonia.Broadcast(aR, b, getBroadcastPattern(aR, b))
+		reshapedA, err = reshapeNode(a, b, true)
 	case len(a.Shape()) != 1 && len(b.Shape()) == 1:
-		// Make an educated guess: find the axis that has the same dimension
-		aShape := a.Shape()
-		dims := make([]int, len(aShape))
-		for i := 0; i < len(aShape); i++ {
-			dims[i] = 1
-			if aShape[i] == b.Shape()[0] {
-				dims[i] = aShape[i]
-			}
-		}
-		// Reshape node a
-		bR, err := gorgonia.Reshape(b, dims)
-		if err != nil {
-			return nil, nil, err
-		}
-		return gorgonia.Broadcast(a, bR, getBroadcastPattern(a, bR))
-	case len(a.Shape()) == 3 && len(b.Shape()) == 4:
-		// Reshape node a
-		aR, err := gorgonia.Reshape(a, append([]int{1}, a.Shape()...))
-		if err != nil {
-			return nil, nil, err
-		}
-		return gorgonia.Broadcast(aR, b, getBroadcastPattern(aR, b))
+		reshapedB, err = reshapeNode(b, a, true)
 	case len(a.Shape()) == 2 && len(b.Shape()) == 2:
-		// Reshape node a
-		return gorgonia.Broadcast(a, b, getBroadcastPattern(a, b))
+		// No reshaping needed
+	case len(a.Shape()) == 3 && len(b.Shape()) == 4:
+		reshapedA, err = gorgonia.Reshape(a, append([]int{1}, a.Shape()...))
 	case len(a.Shape()) == 4 && len(b.Shape()) == 3:
-		// Reshape node a
-		bR, err := gorgonia.Reshape(b, append([]int{1}, b.Shape()...))
-		if err != nil {
-			return nil, nil, err
-		}
-		return gorgonia.Broadcast(a, bR, getBroadcastPattern(a, bR))
+		reshapedB, err = gorgonia.Reshape(b, append([]int{1}, b.Shape()...))
 	default:
 		return a, b, &onnx.ErrNotImplemented{
 			Message: fmt.Sprintf("broadcast not yet implemented for shape %v, %v", a.Shape(), b.Shape()),
 		}
 
 	}
+	if err != nil {
+		return nil, nil, err
+	}
+	return gorgonia.Broadcast(reshapedA, reshapedB, getBroadcastPattern(reshapedA, reshapedB))
+}
+
+func reshapeNode(n1, n2 *gorgonia.Node, findAxis bool) (*gorgonia.Node, error) {
+	dimN2 := n2.Shape()
+	dimReshapeN1 := make([]int, len(dimN2))
+	for i := 0; i < len(dimN2); i++ {
+		dimReshapeN1[i] = 1
+		if findAxis && dimN2[i] == n1.Shape()[0] {
+			// Make an educated guess: find the axis that has the same dimension
+			dimReshapeN1[i] = dimN2[i]
+		}
+	}
+	reshapeN1, err := gorgonia.Reshape(n1, dimReshapeN1)
+	if err != nil {
+		return nil, err
+	}
+	return reshapeN1, nil
 }
 
 func sameDim(a, b *gorgonia.Node) bool {

--- a/backend/x/gorgonnx/conv.go
+++ b/backend/x/gorgonnx/conv.go
@@ -109,14 +109,16 @@ func (c *conv) apply(g *Graph, ns ...*Node) error {
 func (c *conv) init(o onnx.Operation) error {
 	autoPad, ok := o.Attributes["auto_pad"]
 	if ok {
-		switch autoPad.(string) {
-		case "NOTSET":
-		case "VALID":
-			c.pad = []int{0, 0}
-		default:
-			c.autopad = autoPad.(string)
-		}
+		c.autopad = autoPad.(string)
 	}
+	c.initKernelShape(o)
+	err := c.initPads(o)
+	c.initStrides(o)
+	c.initDilations(o)
+	return err
+}
+
+func (c *conv) initKernelShape(o onnx.Operation) {
 	kernelShape, ok := o.Attributes["kernel_shape"]
 	if ok {
 		if kernelShape, ok := kernelShape.([]int64); ok {
@@ -126,6 +128,9 @@ func (c *conv) init(o onnx.Operation) error {
 			}
 		}
 	}
+}
+
+func (c *conv) initPads(o onnx.Operation) error {
 	c.pad = []int{0, 0}
 	pad, ok := o.Attributes["pads"]
 	if ok {
@@ -151,6 +156,10 @@ func (c *conv) init(o onnx.Operation) error {
 			}
 		}
 	}
+	return nil
+}
+
+func (c *conv) initStrides(o onnx.Operation) {
 	c.stride = []int{1, 1}
 	stride, ok := o.Attributes["strides"]
 	if ok {
@@ -166,6 +175,9 @@ func (c *conv) init(o onnx.Operation) error {
 			}
 		}
 	}
+}
+
+func (c *conv) initDilations(o onnx.Operation) {
 	c.dilation = []int{1, 1}
 	dilation, ok := o.Attributes["dilations"]
 	if ok {
@@ -176,5 +188,4 @@ func (c *conv) init(o onnx.Operation) error {
 			}
 		}
 	}
-	return nil
 }

--- a/backend/x/gorgonnx/gap.go
+++ b/backend/x/gorgonnx/gap.go
@@ -84,42 +84,14 @@ func (g *gap) Do(inputs ...gorgonia.Value) (gorgonia.Value, error) {
 		output := tensor.New(tensor.Of(v.Dtype()), tensor.WithShape(s...))
 		switch v.Dtype() {
 		case tensor.Float64:
-			for b := 0; b < B; b++ {
-				for c := 0; c < C; c++ {
-					var sum float64
-					for h := 0; h < H; h++ {
-						for w := 0; w < W; w++ {
-							val, err := v.At(b, c, h, w)
-							if err != nil {
-								return nil, err
-							}
-							sum += val.(float64)
-						}
-					}
-					err := output.SetAt(sum/float64(H*W), b, c, 0, 0)
-					if err != nil {
-						return nil, err
-					}
-				}
+			err = setFloat64AtTensor(v, B, C, H, W, output)
+			if err != nil {
+				return nil, err
 			}
 		case tensor.Float32:
-			for b := 0; b < B; b++ {
-				for c := 0; c < C; c++ {
-					var sum float32
-					for h := 0; h < H; h++ {
-						for w := 0; w < W; w++ {
-							val, err := v.At(b, c, h, w)
-							if err != nil {
-								return nil, err
-							}
-							sum += val.(float32)
-						}
-					}
-					err := output.SetAt(sum/float32(H*W), b, c, 0, 0)
-					if err != nil {
-						return nil, err
-					}
-				}
+			err = setFloat32AtTensor(v, B, C, H, W, output)
+			if err != nil {
+				return nil, err
 			}
 		default:
 			return nil, &onnx.ErrNotImplemented{
@@ -136,6 +108,50 @@ func (g *gap) Do(inputs ...gorgonia.Value) (gorgonia.Value, error) {
 			Message:  fmt.Sprintf("invalid input %v", inputs),
 		}
 	}
+}
+
+func setFloat64AtTensor(v tensor.Tensor, B, C, H, W int, output tensor.Tensor) error {
+	for b := 0; b < B; b++ {
+		for c := 0; c < C; c++ {
+			var sum float64
+			for h := 0; h < H; h++ {
+				for w := 0; w < W; w++ {
+					val, err := v.At(b, c, h, w)
+					if err != nil {
+						return err
+					}
+					sum += val.(float64)
+				}
+			}
+			err := output.SetAt(sum/float64(H*W), b, c, 0, 0)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func setFloat32AtTensor(v tensor.Tensor, B, C, H, W int, output tensor.Tensor) error {
+	for b := 0; b < B; b++ {
+		for c := 0; c < C; c++ {
+			var sum float32
+			for h := 0; h < H; h++ {
+				for w := 0; w < W; w++ {
+					val, err := v.At(b, c, h, w)
+					if err != nil {
+						return err
+					}
+					sum += val.(float32)
+				}
+			}
+			err := output.SetAt(sum/float32(H*W), b, c, 0, 0)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func (g *gap) ReturnsPtr() bool {


### PR DESCRIPTION
With reduction of cyclomatic complexities in

* `ggnBroadcast`of `backend/x/gorgonnx/broadcast.go`
* `(*maxpool).init` of `backend/x/gorgonnx/maxpool.go`
* `(*conv).init` of `backend/x/gorgonnx/conv.go`
* `(*gap).Do` of `backend/x/gorgonnx/gap.go`
* `(*gemm).do64` of `backend/x/gorgonnx/gemm.go`
* `(*gemm).do32` of `backend/x/gorgonnx/gemm.go`
* `(*fastBatchnorm).Do` of `backend/x/gorgonnx/batchnorm_op.go`
* `(*fastBatchnorm).check` of `backend/x/gorgonnx/batchnorm_op.go`

Also fix a bug on wrongful broadcast when node `a` shape is equals to 0.

Linked to #130 