### PR TITLE
Fixed panic when working with empty floats.

### DIFF
--- a/internal/onnx/ir/tensor.go
+++ b/internal/onnx/ir/tensor.go
@@ -90,6 +90,9 @@ func generateConsOptsFromBoolTensor(tx *TensorProto) ([]tensor.ConsOpt, error) {
 func generateConsOptsFromFloat32Tensor(tx *TensorProto) ([]tensor.ConsOpt, error) {
 	switch {
 	case tx.RawData != nil:
+		if len(tx.RawData) == 0 {
+			return []tensor.ConsOpt{tensor.WithBacking([]float32{})}, nil
+		}
 		buf := bytes.NewReader(tx.RawData)
 		element := make([]byte, 4)
 		var err error
@@ -119,6 +122,9 @@ func generateConsOptsFromFloat64Tensor(tx *TensorProto) ([]tensor.ConsOpt, error
 	case tx.DoubleData != nil:
 		return []tensor.ConsOpt{tensor.WithBacking(tx.DoubleData)}, nil
 	case tx.RawData != nil:
+		if len(tx.RawData) == 0 {
+			return []tensor.ConsOpt{tensor.WithBacking([]float64{})}, nil
+		}
 		buf := bytes.NewReader(tx.RawData)
 		element := make([]byte, 8)
 		var err error

--- a/internal/onnx/ir/tensor_test.go
+++ b/internal/onnx/ir/tensor_test.go
@@ -510,3 +510,53 @@ func TestNewTensor_int64_noData(t *testing.T) {
 	_, err := txInt64.Tensor()
 	assert.EqualError(t, err, "No data found")
 }
+
+func TestNewTensor_float32_raw_empty(t *testing.T) {
+	dims := []int64{0}
+	dataType := TensorProto_DataType(TensorProto_DataType_value["FLOAT"])
+	rawData := []byte{}
+	name := "testFloat"
+	txFloat32 := &TensorProto{
+		Dims:       dims,
+		DataType:   int32(dataType),
+		Segment:    (*TensorProto_Segment)(nil),
+		FloatData:  nil,
+		Int32Data:  nil,
+		StringData: nil,
+		Int64Data:  nil,
+		Name:       name,
+		DocString:  "",
+		RawData:    rawData,
+		DoubleData: nil,
+		Uint64Data: nil,
+	}
+	_, err := txFloat32.Tensor()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNewTensor_float64_raw_empty(t *testing.T) {
+	dims := []int64{0}
+	dataType := TensorProto_DataType(TensorProto_DataType_value["DOUBLE"])
+	rawData := []byte{}
+	name := "testFloat"
+	txFloat64 := &TensorProto{
+		Dims:       dims,
+		DataType:   int32(dataType),
+		Segment:    (*TensorProto_Segment)(nil),
+		FloatData:  nil,
+		Int32Data:  nil,
+		StringData: nil,
+		Int64Data:  nil,
+		Name:       name,
+		DocString:  "",
+		RawData:    rawData,
+		DoubleData: nil,
+		Uint64Data: nil,
+	}
+	_, err := txFloat64.Tensor()
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
In Tensorflow there is a variable [type](https://github.com/onnx/tensorflow-onnx/blob/master/tf2onnx/onnx_opset/nn.py#L1144) for empty floats, which are represented as empty arrays. When importing a model that uses this type (e.g. [yolov4](https://github.com/onnx/models/tree/master/vision/object_detection_segmentation/yolov4)), onnx-go panics like this:

```
panic: runtime error: index out of range [0] with length 0 [recovered]
	panic: runtime error: index out of range [0] with length 0

goroutine 6 [running]:
testing.tRunner.func1.1(0xd42be0, 0xc000026c40)
	/usr/local/go/src/testing/testing.go:940 +0x2f5
testing.tRunner.func1(0xc00012bc20)
	/usr/local/go/src/testing/testing.go:943 +0x3f9
panic(0xd42be0, 0xc000026c40)
	/usr/local/go/src/runtime/panic.go:969 +0x166
gorgonia.org/tensor.StdEng.makeArray(0xc00012bd78, 0xeb13a0, 0xc9e2a0, 0x0)
	/home/alexvish/go/pkg/mod/gorgonia.org/tensor@v0.9.11/defaultengine.go:22 +0xf7
gorgonia.org/tensor.(*Dense).makeArray(0xc00012bd40, 0x0)
	/home/alexvish/go/pkg/mod/gorgonia.org/tensor@v0.9.11/dense.go:87 +0x196
gorgonia.org/tensor.(*Dense).fix(0xc00012bd40)
	/home/alexvish/go/pkg/mod/gorgonia.org/tensor@v0.9.11/dense.go:292 +0x11a
gorgonia.org/tensor.New(0xc00000f020, 0x3, 0x4, 0x2)
	/home/alexvish/go/pkg/mod/gorgonia.org/tensor@v0.9.11/tensor.go:93 +0x77
github.com/owulveryck/onnx-go/internal/onnx/ir.(*TensorProto).Tensor(0xc000052660, 0xc0001a8840, 0xd8a347, 0x5, 0xc000135948)
	/home/alexvish/src/go/onnx-go/internal/onnx/ir/tensor.go:51 +0x369
github.com/owulveryck/onnx-go/internal/onnx/ir.TestNewTensor_float32_raw_empty(0xc00012bc20)
	/home/alexvish/src/go/onnx-go/internal/onnx/ir/tensor_test.go:533 +0x189
testing.tRunner(0xc00012bc20, 0xdb18f8)
	/usr/local/go/src/testing/testing.go:991 +0xdc
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1042 +0x357
```

I added a small fix that prevents the code from failing by creating an empty tensor when the length of `RawData` is 0. Checked with `yolov4`, works as expected.